### PR TITLE
Made the restore command more clear

### DIFF
--- a/backupdb/backupdb.py
+++ b/backupdb/backupdb.py
@@ -99,7 +99,7 @@ class BackupDB(commands.Cog):
                 upsert=True,
             )
             await ctx.send(
-                embed=await self.generate_embed(":tada: Backed Up Everything!")
+                embed=await self.generate_embed(":tada: Backed Up Everything!\nTo restore your backup at any time, type `{self.bot.prefix}backup restore`.")
             )
             return
 


### PR DESCRIPTION
I added a string alongside the `Backed up successfully` message stating the command to restore your backup.